### PR TITLE
Allow for submodel validation to occur after the property as a whole has...

### DIFF
--- a/lib/Instance.js
+++ b/lib/Instance.js
@@ -428,15 +428,6 @@ Instance.prototype.doDocumentFieldsHaveError = function (definition, metadata, d
       metadata[i].hasError = hasError;
     }
 
-    // When this is submodel array - validate each sub-object
-    if (mapping && mapping.type === MAPPING_TYPES.SUBMODEL_ARRAY) {
-      for (j in data[i]) {
-        if (!data[i][j].isValid()) {
-          hasError = true;
-          metadata[i].hasError = true;
-        }
-      }
-    }
 
     if (typeof data === 'object') {
       field = data[i];
@@ -503,6 +494,16 @@ Instance.prototype.doDocumentFieldsHaveError = function (definition, metadata, d
         metadata[i].hasError = true;
         metadata[i].lastError = errorMessage;
         break;
+      }
+    }
+
+    // When this is submodel array - validate each sub-object
+    if (mapping && mapping.type === MAPPING_TYPES.SUBMODEL_ARRAY) {
+      for (j in data[i]) {
+        if (!data[i][j].isValid()) {
+          hasError = true;
+          metadata[i].hasError = true;
+        }
       }
     }
   }
@@ -1327,12 +1328,12 @@ Instance.prototype.mapFieldsToSourceInstances = function (data, definition, sour
     sourceName = (mapping.source) ? mapping.source : 'primary';
     instanceWrapper = instances[sourceName];
 
+    // Serialize the data if a searializer function is provided
+    serialized = (mapping.serializer) ? mapping.serializer(data[i]) : data[i];
+
     if (!mapping.type || mapping.type === MAPPING_TYPES.FIELD) {
         // Change the name of the field to its source alias if one exists
       key = mapping.alias || i;
-
-      // Serialize the data if a searializer function is provided
-      serialized = (mapping.serializer) ? mapping.serializer(data[i]) : data[i];
 
       if (!instanceWrapper) {
         instanceWrapper = {
@@ -1363,7 +1364,7 @@ Instance.prototype.mapFieldsToSourceInstances = function (data, definition, sour
         instances[sourceName] = instanceWrapper;
       }
 
-      instanceWrapper.instances = instanceWrapper.instances.concat(data[i]);
+      instanceWrapper.instances = instanceWrapper.instances.concat(serialized);
 
     } else if (mapping.type === MAPPING_TYPES.SUBMODEL_PROPERTY) {
       throw new Error('Submodel properties have not been implemented');


### PR DESCRIPTION
... been validated

This is to allow cleaning functions to be performed first.
