### PR TITLE
SITE-1168: Fix crashes when solr is down

### DIFF
--- a/lib/AbstractSolrSearchModel.js
+++ b/lib/AbstractSolrSearchModel.js
@@ -118,7 +118,7 @@ AbstractSolrSearchModel.prototype.generateListFromSourceCallback = function (sou
 
     // Return only the list if the meta is not included
     if (!options.should_include_meta) {
-      result = list;
+      result = result.list;
     }
 
     callback(null, result);

--- a/lib/SolrClient.js
+++ b/lib/SolrClient.js
@@ -256,6 +256,10 @@ Client.prototype.count = function (params, options, callback) {
     })
   );
 
+  request.on('error', function (err) {
+    callback(err);
+  });
+
   request.end();
 };
 
@@ -291,6 +295,10 @@ Client.prototype.list = function (params, options, callback) {
     })
   );
 
+  request.on('error', function (err) {
+    callback(err);
+  });
+
   request.end();
 };
 
@@ -323,6 +331,10 @@ Client.prototype.import = function (core, command, clean, commit, callback) {
       }
     })
   );
+
+  request.on('error', function (err) {
+    callback(err);
+  });
 
   request.end();
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loverly-frankenstein",
   "description": "The loverly node-js model layer that allows a unified hierarchical structure on top of an assortment of data-storage engines",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "homepage": "https://github.com/loverly/loverly-frankenstein",
   "repository": "https://github.com/loverly/loverly-frankenstein",
   "author": {


### PR DESCRIPTION
- On request error, the server crashes because there is an uncaught
  error on the http request which bubbles to the top level, killing the app
- Add handlers for the error
